### PR TITLE
fix: always emit 'down' when peer has completed and is disconnected

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -357,6 +357,7 @@ class Sync extends EventEmitter {
     function onend (err) {
       if (err) return onerror(err)
       self.osm.ready(function () {
+        self.emit('down', peer)
         emitter.emit('end')
       })
     }


### PR DESCRIPTION
Mapeo Desktop wont ever close before 5 minutes with a syncfile in progress because it is waiting for the 'down' event.. which is only emitted in the swarm.

This can be fixed by emitting `down` in the `onend` function of the syncfile