### PR TITLE
fix: sync bugs with new v8 connected and started properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+- '10'
 - '12'
 os:
 - windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-- '8'
-- '10'
+- '12'
 os:
 - windows
 - osx

--- a/sync.js
+++ b/sync.js
@@ -193,7 +193,6 @@ class Sync extends events.EventEmitter {
 
     // track all peer states
     this.state = new SyncState()
-    this._syncQueue = new Map()
   }
 
   peers () {

--- a/sync.js
+++ b/sync.js
@@ -231,6 +231,13 @@ class Sync extends events.EventEmitter {
       return peer.sync
     }
 
+    if (!peer.connected) {
+      process.nextTick(() => {
+        peer.sync.emit('error', new Error('trying to sync to a peer that is not connected'))
+      })
+      return peer.sync
+    }
+
     peer.handshake.accept()
     delete peer.handshake
     return peer.sync

--- a/sync.js
+++ b/sync.js
@@ -446,11 +446,9 @@ class Sync extends events.EventEmitter {
         })
         stream.once('sync-start', function () {
           debug('sync started', info.host, info.port)
-          if (self.state.activePeers().length + 1 === 1) {
-            self.osm.core.pause(function () {
-              if (peer) peer.sync.emit('sync-start')
-            })
-          }
+          self.osm.core.pause(function () {
+            if (peer) peer.sync.emit('sync-start')
+          })
         })
         stream.on('progress', (progress) => {
           debug('sync progress', info.host, info.port, progress)
@@ -458,7 +456,7 @@ class Sync extends events.EventEmitter {
         })
         pump(stream, connection, stream, function (err) {
           debug('pump ended', info.host, info.port)
-          if (self.state.activePeers().length - 1 === 0) {
+          if (peer && peer.started) {
             self.osm.core.resume()
           }
           if (peer && peer.started && !stream.goodFinish && !err) {

--- a/sync.js
+++ b/sync.js
@@ -161,7 +161,6 @@ class SyncState {
 
   onend (peer) {
     if (this._isclosed(peer)) return
-    peer.connected = false
     if (peer.started) {
       peer.state = PeerState(ReplicationState.COMPLETE, Date.now())
     }
@@ -414,6 +413,7 @@ class Sync extends events.EventEmitter {
 
       function onClose (err) {
         disconnected = true
+        if (peer) peer.connected = false
         debug('onClose', info.host, info.port, err)
         if (!open) return
         open = false

--- a/sync.js
+++ b/sync.js
@@ -226,8 +226,7 @@ class Sync extends events.EventEmitter {
   replicateNetwork (peer, opts) {
     if (!peer.handshake) {
       process.nextTick(() => {
-        this._syncQueue.set(peer.id, peer)
-        // peer.sync.emit('error', new Error('trying to sync before handshake has occurred'))
+        peer.sync.emit('error', new Error('trying to sync before handshake has occurred'))
       })
       return peer.sync
     }
@@ -477,18 +476,10 @@ class Sync extends events.EventEmitter {
         peer.handshake = { accept: accept }
         peer.deviceType = req.deviceType
         peer.name = req.deviceName
-        self._drainQueue()
         self.emit('peer', peer)
       }
     })
     return swarm
-  }
-
-  _drainQueue () {
-    for (let [peerId, peer] of this._syncQueue) {
-      this._syncQueue.delete(peerId)
-      this.replicate(peer)
-    }
   }
 }
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -29,6 +29,10 @@ function createApi (_dir, opts) {
     id: randombytes(8).toString('hex')
   }))
 
+  osm.close = function (cb) {
+    this.index.close(cb)
+  }
+
   mapeo._dir = dir
   return mapeo
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -17,8 +17,8 @@ module.exports = {
   generateObservations
 }
 
-function createApi (_, opts) {
-  var dir = tmp.dirSync().name
+function createApi (_dir, opts) {
+  var dir = _dir || tmp.dirSync().name
 
   mkdirp.sync(dir)
 
@@ -28,10 +28,6 @@ function createApi (_, opts) {
   var mapeo = new Mapeo(osm, media, Object.assign({}, opts, {
     id: randombytes(8).toString('hex')
   }))
-
-  osm.close = function (cb) {
-    this.index.close(cb)
-  }
 
   mapeo._dir = dir
   return mapeo

--- a/test/sync.js
+++ b/test/sync.js
@@ -1031,12 +1031,12 @@ tape('sync: peer.connected property on graceful exit', function (t) {
   })
 })
 
-tape('sync: 200 photos & close/reopen real-world scenario', function (t) {
-  t.plan(15)
+tape.only('sync: 200 photos & close/reopen real-world scenario', function (t) {
+  t.plan(17)
   var opts = {api1:{deviceType:'desktop'}, api2:{deviceType:'desktop'}}
   createApis(opts, function (api1, api2, close) {
     var pending = 4
-    var total = 200
+    var total = 5
     var _api1 = null
 
     api1.sync.once('peer', written.bind(null, null))
@@ -1080,8 +1080,13 @@ tape('sync: 200 photos & close/reopen real-world scenario', function (t) {
     }
 
     function done (cb) {
-      _api1.close(() => {
+      // CLOSE ONE SIDE and see that it is not connected anymore
+      api2.sync.on('down', () => {
+        t.pass('emit down event on close')
         close(cb)
+      })
+      _api1.close(() => {
+        t.notOk(api2.sync.peers()[0].connected, 'not connected anymore')
       })
     }
 

--- a/test/sync.js
+++ b/test/sync.js
@@ -22,8 +22,8 @@ function createApis (opts, cb) {
     var pending = 2
     function done () {
       if (!--pending) {
-        api1.close(function () {
-          api2.close(function () {
+        api1.osm.close(function () {
+          api2.osm.close(function () {
             rimraf(api1._dir, function () {
               rimraf(api2._dir, function () {
                 cb()
@@ -1059,18 +1059,20 @@ tape('sync: 200 photos & close/reopen real-world scenario', function (t) {
           // TEST: close one side and then re-open it before syncing
           api1.sync.leave()
           api1.close(() => {
-            _api1 = helpers.createApi(api1._dir)
-            _api1.sync.listen(() => {
-              _api1.sync.join()
+            api1.osm.close(() => {
+              _api1 = helpers.createApi(api1._dir)
+              _api1.sync.listen(() => {
+                _api1.sync.join()
 
-              // wait to sync until we have the handshake and are connected
-              var interval = setInterval(() => {
-                var peer = api2.sync.peers()[0]
-                if (peer.connected && peer.handshake) {
-                  sync(peer)
-                  clearInterval(interval)
-                }
-              }, 200)
+                // wait to sync until we have the handshake and are connected
+                var interval = setInterval(() => {
+                  var peer = api2.sync.peers()[0]
+                  if (peer.connected && peer.handshake) {
+                    sync(peer)
+                    clearInterval(interval)
+                  }
+                }, 200)
+              })
             })
           })
         }

--- a/test/sync.js
+++ b/test/sync.js
@@ -623,7 +623,7 @@ tape('sync: deletes are not synced back', function (t) {
                     t.same(after.length, results.length - 1, 'one less item in list')
                     close(() => t.pass('close ok'))
                   })
-                }, 100)
+                }, 1000)
               })
             })
           })

--- a/test/sync.js
+++ b/test/sync.js
@@ -613,14 +613,17 @@ tape('sync: deletes are not synced back', function (t) {
               var syncer = api1.sync.replicate(peer)
               syncer.once('error', (err) => t.error(err))
               syncer.once('end', () => {
-                // wait for the indexers to warm up
-                api2.osm.ready(() => {
+                // XXX: race condition where the indexers haven't warmed back
+                // up after syncing yet, but an API request is being made on
+                // the view immediately, resulting in stale data being given
+                // back (unless we wait for a bit)
+                setTimeout(() => {
                   api2.observationList(function (err, after) {
                     t.error(err)
                     t.same(after.length, results.length - 1, 'one less item in list')
                     close(() => t.pass('close ok'))
                   })
-                })
+                }, 100)
               })
             })
           })

--- a/test/sync.js
+++ b/test/sync.js
@@ -586,7 +586,7 @@ tape('sync: deletes are not synced back', function (t) {
     api2.sync.listen(() => {
       api2.sync.join()
     })
-    helpers.writeBigData(api1, total, written)
+    helpers.writeBigData(api1, total, written)  // write 5 entries
     writeBlob(api2, 'goodbye_world.png', written)
 
     function written (err) {
@@ -623,7 +623,7 @@ tape('sync: deletes are not synced back', function (t) {
                     t.same(after.length, results.length - 1, 'one less item in list')
                     close(() => t.pass('close ok'))
                   })
-                }, 3000)
+                }, 100)
               })
             })
           })

--- a/test/sync.js
+++ b/test/sync.js
@@ -623,7 +623,7 @@ tape('sync: deletes are not synced back', function (t) {
                     t.same(after.length, results.length - 1, 'one less item in list')
                     close(() => t.pass('close ok'))
                   })
-                }, 1000)
+                }, 3000)
               })
             })
           })

--- a/test/sync.js
+++ b/test/sync.js
@@ -489,7 +489,7 @@ tape('sync: desktop <-> desktop photos', function (t) {
   var opts = {api1:{deviceType:'desktop'}, api2:{deviceType:'desktop'}}
   createApis(opts, function (api1, api2, close) {
     var pending = 4
-    var total = 5
+    var total = 200
     var lastProgress
 
     api2.sync.setName('device_2')
@@ -1031,8 +1031,8 @@ tape('sync: peer.connected property on graceful exit', function (t) {
   })
 })
 
-tape.only('sync: 200 photos & close/reopen real-world scenario', function (t) {
-  t.plan(17)
+tape('sync: 200 photos & close/reopen real-world scenario', function (t) {
+  t.plan(18)
   var opts = {api1:{deviceType:'desktop'}, api2:{deviceType:'desktop'}}
   createApis(opts, function (api1, api2, close) {
     var pending = 4
@@ -1081,16 +1081,17 @@ tape.only('sync: 200 photos & close/reopen real-world scenario', function (t) {
 
     function done (cb) {
       // CLOSE ONE SIDE and see that it is not connected anymore
-      api2.sync.on('down', () => {
-        t.pass('emit down event on close')
-        close(cb)
-      })
       _api1.close(() => {
         t.notOk(api2.sync.peers()[0].connected, 'not connected anymore')
+        close(cb)
       })
     }
 
     function sync (peer) {
+      api2.sync.on('down', () => {
+        t.pass('emit down event on close')
+        t.notOk(api2.sync.peers()[0].connected, 'not connected anymore')
+      })
       var syncer = api2.sync.replicate(peer)
       syncer.on('error', function (err) {
         t.error(err)

--- a/test/sync.js
+++ b/test/sync.js
@@ -1063,15 +1063,8 @@ tape('sync: 200 photos & close/reopen real-world scenario', function (t) {
               _api1 = helpers.createApi(api1._dir)
               _api1.sync.listen(() => {
                 _api1.sync.join()
-
-                // wait to sync until we have the handshake and are connected
-                var interval = setInterval(() => {
-                  var peer = api2.sync.peers()[0]
-                  if (peer.connected && peer.handshake) {
-                    sync(peer)
-                    clearInterval(interval)
-                  }
-                }, 200)
+                var peer = api2.sync.peers()[0]
+                sync(peer)
               })
             })
           })

--- a/test/sync.js
+++ b/test/sync.js
@@ -489,7 +489,7 @@ tape('sync: desktop <-> desktop photos', function (t) {
   var opts = {api1:{deviceType:'desktop'}, api2:{deviceType:'desktop'}}
   createApis(opts, function (api1, api2, close) {
     var pending = 4
-    var total = 200
+    var total = 5
     var lastProgress
 
     api2.sync.setName('device_2')

--- a/test/sync.js
+++ b/test/sync.js
@@ -1036,7 +1036,7 @@ tape('sync: 200 photos & close/reopen real-world scenario', function (t) {
   var opts = {api1:{deviceType:'desktop'}, api2:{deviceType:'desktop'}}
   createApis(opts, function (api1, api2, close) {
     var pending = 4
-    var total = 5
+    var total = 200
     var _api1 = null
 
     api1.sync.once('peer', written.bind(null, null))
@@ -1062,9 +1062,10 @@ tape('sync: 200 photos & close/reopen real-world scenario', function (t) {
             api1.osm.close(() => {
               _api1 = helpers.createApi(api1._dir)
               _api1.sync.listen(() => {
+                api2.sync.once('peer', (peer) => {
+                  sync(peer)
+                })
                 _api1.sync.join()
-                var peer = api2.sync.peers()[0]
-                sync(peer)
               })
             })
           })

--- a/test/sync.js
+++ b/test/sync.js
@@ -613,17 +613,14 @@ tape('sync: deletes are not synced back', function (t) {
               var syncer = api1.sync.replicate(peer)
               syncer.once('error', (err) => t.error(err))
               syncer.once('end', () => {
-                // XXX: race condition where the indexers haven't warmed back
-                // up after syncing yet, but an API request is being made on
-                // the view immediately, resulting in stale data being given
-                // back (unless we wait for a bit)
-                setTimeout(() => {
+                // wait for the indexers to warm up
+                api2.osm.ready(() => {
                   api2.observationList(function (err, after) {
                     t.error(err)
                     t.same(after.length, results.length - 1, 'one less item in list')
                     close(() => t.pass('close ok'))
                   })
-                }, 100)
+                })
               })
             })
           })


### PR DESCRIPTION
Found these bugs while updating Mapeo Desktop to the latest v8.

This will be published as @mapeo/core v8.2.2

## Sync peers should always emit the close event

Added a failing (now passing!) test where `peer.started` was never getting set, which lead to the `replication-complete` state never firing.

For example, this state should not exist, where `replication-progress` is the state and `started` is false.

![Screenshot from 2020-06-27 00-25-01](https://user-images.githubusercontent.com/633012/85918175-30286880-b815-11ea-982e-c4884513580f.png)

The test also captures this by making sure `peer.started` is set on the first progress event.

The culprit?

`self._activeSyncs` gets into an incorrect state when a peer would disconnect without syncing, and then reconnect.

Peer A joins
Peer B joins
Peer A closes
-1 activeSyncs
Peer A joins
Peer B syncs with Peer A
-1 activeSyncs + 1 = 0
0 activeSyncs means that `sync-start` is never emitted

## Sending `replicateNetwork` too quickly would sometimes not do anything 

If `peer.connected` the sync start doesn't go through and nothing happens.

Now, it sends an error if the peer is not connected when `replicate` is called.

See https://github.com/digidem/mapeo-core/pull/94/files#diff-39367c259f0252fc4bc764d86564411bR234-R239

An alternative way to do this would be to create an internal queue of syncronizations that have been requested, and once a peer reconnects, see if a replication has already been requested and drain that queue. But this seemed to be unnecessary as consumer applications should not allow syncronization if the peer is disconnected. (although it would be a *nice to have* convenience for developer ux)

## Syncronizing and then disconnecting would not properly set `peer.connected = false`

Peer A joins
Peer B joins 
Peer B and A syncronize
Peer A quits
`peer.connected` is `true` during the `down` event. It should be `false` as the peer is now disconnected.

This is fixed by setting `peer.connected = false` in the `onClose` function before the `down` event is emitted with the peer -- otherwise a consumer application will think that the peer is still connected when it is not. 

See https://github.com/digidem/mapeo-core/pull/94/files#diff-39367c259f0252fc4bc764d86564411bR422