### PR TITLE
fix: always end sync, even when there is missing data

### DIFF
--- a/lib/db-sync-progress.js
+++ b/lib/db-sync-progress.js
@@ -10,12 +10,15 @@ module.exports = function (db, opts) {
 
   multifeed.ready(function () {
     multifeed.feeds().forEach(onFeed)
-    stream.on('remote-feeds', () => {
+    stream.on('remote-feeds', onRemoteFeeds)
+
+    function onRemoteFeeds () {
       multifeed.feeds().forEach(onFeed)
-    })
+    }
 
     eos(stream, function () {
       multifeed.removeListener('feed', onFeed)
+      stream.removeListener('remote-feeds', onRemoteFeeds)
       listeners.forEach(function (l) {
         l.feed.removeListener('upload', l.listener)
         l.feed.removeListener('download', l.listener)
@@ -44,7 +47,7 @@ module.exports = function (db, opts) {
       return acc + feed.length
     }, 0)
     var sofar = all.reduce(function (acc, feed) {
-      return acc + feed.stats.totals.downloadedBlocks + feed.stats.totals.uploadedBlocks
+      return acc + feed.downloaded(0, feed.length)
     }, 0)
     stream.emit('progress', sofar, total)
   }

--- a/lib/db-sync-progress.js
+++ b/lib/db-sync-progress.js
@@ -5,17 +5,19 @@ module.exports = function (db, opts) {
 
   var stream = multifeed.replicate(opts)
 
-  var feeds = []
-  var progress = {}
+  var feeds = new Map()
   var listeners = []
 
   multifeed.ready(function () {
     multifeed.feeds().forEach(onFeed)
-    multifeed.on('feed', onFeed)
+    stream.on('remote-feeds', () => {
+      multifeed.feeds().forEach(onFeed)
+    })
 
     eos(stream, function () {
       multifeed.removeListener('feed', onFeed)
       listeners.forEach(function (l) {
+        l.feed.removeListener('upload', l.listener)
         l.feed.removeListener('download', l.listener)
       })
     })
@@ -24,19 +26,26 @@ module.exports = function (db, opts) {
   return stream
 
   function onFeed (feed) {
-    feeds.push(feed)
+    if (feeds.has(feed)) return
+    feeds.set(feed.key, feed)
     feed.ready(updateFeed.bind(null, feed))
-    feed.on('download', onDownload)
-    function onDownload () {
+    feed.on('download', listener)
+    feed.on('upload', listener)
+
+    function listener () {
       updateFeed(feed)
     }
-    listeners.push({ feed: feed, listener: onDownload })
+    listeners.push({ feed, listener })
   }
 
   function updateFeed (feed) {
-    progress[feed.key.toString('hex')] = feed.downloaded(0, feed.length)
-    var total = feeds.reduce(function (acc, feed) { return acc + feed.length }, 0)
-    var sofar = feeds.reduce(function (acc, feed) { return acc + feed.downloaded(0, feed.length) }, 0)
+    var all = Array.from(feeds.values())
+    var total = all.reduce(function (acc, feed) {
+      return acc + feed.length
+    }, 0)
+    var sofar = all.reduce(function (acc, feed) {
+      return acc + feed.stats.totals.downloadedBlocks + feed.stats.totals.uploadedBlocks
+    }, 0)
     stream.emit('progress', sofar, total)
   }
 }

--- a/lib/db-sync-progress.js
+++ b/lib/db-sync-progress.js
@@ -10,6 +10,7 @@ module.exports = function (db, opts) {
 
   multifeed.ready(function () {
     multifeed.feeds().forEach(onFeed)
+    multifeed.on('feed', onFeed)
     stream.on('remote-feeds', onRemoteFeeds)
 
     function onRemoteFeeds () {
@@ -29,8 +30,8 @@ module.exports = function (db, opts) {
   return stream
 
   function onFeed (feed) {
-    if (feeds.has(feed.key.toString('hex'))) return
-    feeds.set(feed.key, feed)
+    if (!feed.writable && feeds.has(feed.key.toString('hex'))) return
+    feeds.set(feed.key.toString('hex'), feed)
     feed.ready(updateFeed.bind(null, feed))
     feed.on('download', listener)
     feed.on('upload', listener)

--- a/lib/db-sync-progress.js
+++ b/lib/db-sync-progress.js
@@ -26,7 +26,7 @@ module.exports = function (db, opts) {
   return stream
 
   function onFeed (feed) {
-    if (feeds.has(feed)) return
+    if (feeds.has(feed.key.toString('hex'))) return
     feeds.set(feed.key, feed)
     feed.ready(updateFeed.bind(null, feed))
     feed.on('download', listener)

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "handshake-stream": "^3.0.0",
     "hypercore-crypto": "^1.0.0",
     "inherits": "^2.0.3",
-    "multifeed": "github:kappa-db/multifeed#v4-remote-feeds",
+    "multifeed": "^4.3.0",
     "multiplex": "^6.7.0",
     "osm-p2p-geojson": "^4.0.1",
     "osm-p2p-syncfile": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "handshake-stream": "^3.0.0",
     "hypercore-crypto": "^1.0.0",
     "inherits": "^2.0.3",
+    "multifeed": "github:kappa-db/multifeed#v4-remote-feeds",
     "multiplex": "^6.7.0",
     "osm-p2p-geojson": "^4.0.1",
     "osm-p2p-syncfile": "^4.1.0",

--- a/sync.js
+++ b/sync.js
@@ -459,7 +459,7 @@ class Sync extends events.EventEmitter {
           // Ideally, we'd open a sparse hypercore instead.
           heartbeat = setInterval(() => {
             if (self.state.stale(peer)) {
-              connection.destroy(new Error('missing data'))
+              connection.destroy(new Error('timed out due to missing data'))
             }
           }, DEFAULT_HEARTBEAT_INTERVAL)
         })

--- a/sync.js
+++ b/sync.js
@@ -36,7 +36,7 @@ const DEFAULT_INTERNET_DISCO = Object.assign(
   }
 )
 
-const DEFAULT_HEARTBEAT_INTERVAL = 1000 * 5 // 10 seconds
+const DEFAULT_HEARTBEAT_INTERVAL = 1000 * 20 // 20 seconds
 
 const ReplicationState = {
   WIFI_READY: 'replication-wifi-ready',

--- a/sync.js
+++ b/sync.js
@@ -461,6 +461,7 @@ class Sync extends events.EventEmitter {
             if (self.state.stale(peer)) {
               connection.destroy(new Error('timed out due to missing data'))
             }
+            debug('heartbeat', self.state.stale(peer))
           }, DEFAULT_HEARTBEAT_INTERVAL)
         })
         stream.on('progress', (progress) => {

--- a/sync.js
+++ b/sync.js
@@ -36,6 +36,8 @@ const DEFAULT_INTERNET_DISCO = Object.assign(
   }
 )
 
+const DEFAULT_HEARTBEAT_INTERVAL = 1000 * 5 // 10 seconds
+
 const ReplicationState = {
   WIFI_READY: 'replication-wifi-ready',
   PROGRESS: 'replication-progress',
@@ -97,8 +99,10 @@ class SyncState {
     }
   }
 
-  activePeers () {
-    return this.peers().filter(this._isactive)
+  stale (peer) {
+    var staleDate = Date.now() - DEFAULT_HEARTBEAT_INTERVAL
+    return peer.state.topic === ReplicationState.PROGRESS &&
+      (peer.state.message.timestamp < staleDate)
   }
 
   _isactive (peer) {
@@ -146,6 +150,7 @@ class SyncState {
 
   onprogress (peer, progress) {
     if (this._isclosed(peer)) return
+    progress.timestamp = Date.now()
     peer.state = PeerState(ReplicationState.PROGRESS, progress)
   }
 
@@ -408,6 +413,7 @@ class Sync extends events.EventEmitter {
       let peer
       let deviceType
       let disconnected = false
+      let heartbeat
 
       connection.on('close', onClose)
       connection.on('error', onClose)
@@ -419,6 +425,7 @@ class Sync extends events.EventEmitter {
       function onClose (err) {
         disconnected = true
         if (peer) peer.connected = false
+        if (heartbeat) clearInterval(heartbeat)
         debug('onClose', info.host, info.port, err)
         if (!open) return
         open = false
@@ -448,11 +455,19 @@ class Sync extends events.EventEmitter {
           debug('sync started', info.host, info.port)
           if (peer) peer.sync.emit('sync-start')
           self.osm.core.pause()
+          // XXX: This is a hack to ensure sync streams always end eventually
+          // Ideally, we'd open a sparse hypercore instead.
+          heartbeat = setInterval(() => {
+            if (self.state.stale(peer)) {
+              connection.destroy(new Error('missing data'))
+            }
+          }, DEFAULT_HEARTBEAT_INTERVAL)
         })
         stream.on('progress', (progress) => {
           debug('sync progress', info.host, info.port, progress)
           if (peer) peer.sync.emit('progress', progress)
         })
+
         pump(stream, connection, stream, function (err) {
           debug('pump ended', info.host, info.port)
           if (peer && peer.started) {

--- a/test/db-sync-progress.js
+++ b/test/db-sync-progress.js
@@ -63,8 +63,8 @@ test('sync progress: 6 entries', function (t) {
       var a = sync(db1, { live: false })
       var b = sync(db2, { live: false })
 
-      var eventsLeftA = 5
-      var eventsLeftB = 5
+      var eventsLeftA = 12
+      var eventsLeftB = 12
       a.on('progress', function (sofar, total) {
         eventsLeftA--
       })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -42,7 +42,6 @@ function writeBigDataNoPhotos (mapeo, n, cb) {
   generateObservations(n, function (_, obs, i) {
     mapeo.observationCreate(obs, (_, node) => {
       if (i === 0) {
-        console.log('done')
         cb()
       }
     })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -13,6 +13,7 @@ var Mapeo = require('..')
 
 module.exports = {
   createApi,
+  writeBigDataNoPhotos,
   writeBigData,
   generateObservations
 }
@@ -35,6 +36,17 @@ function createApi (_dir, opts) {
 
   mapeo._dir = dir
   return mapeo
+}
+
+function writeBigDataNoPhotos (mapeo, n, cb) {
+  generateObservations(n, function (_, obs, i) {
+    mapeo.observationCreate(obs, (_, node) => {
+      if (i === 0) {
+        console.log('done')
+        cb()
+      }
+    })
+  })
 }
 
 function writeBigData (mapeo, n, cb) {

--- a/test/sync.js
+++ b/test/sync.js
@@ -340,6 +340,7 @@ tape('sync: syncfile replication: osm-p2p-syncfile', function (t) {
 
     function syncfileWritten (err) {
       t.error(err, 'first syncfile written ok')
+      delete lastProgress.timestamp
       t.deepEquals(lastProgress, {
         db: { sofar: 1, total: 1 },
         media: { sofar: 1, total: 1 }
@@ -355,6 +356,7 @@ tape('sync: syncfile replication: osm-p2p-syncfile', function (t) {
 
     function secondSyncfileWritten (err) {
       t.error(err, 'second syncfile written ok')
+      delete lastProgress.timestamp
       t.deepEquals(lastProgress, {
         db: { sofar: 1, total: 1 },
         media: { sofar: 1, total: 1 }
@@ -444,6 +446,7 @@ tape('sync: syncfile /wo projectKey, api with projectKey set', function (t) {
 
     function syncfileWritten (err) {
       t.error(err, 'first syncfile written ok')
+      delete lastProgress.timestamp
       t.deepEquals(lastProgress, {
         db: { sofar: 1, total: 1 },
         media: { sofar: 1, total: 1 }
@@ -459,6 +462,7 @@ tape('sync: syncfile /wo projectKey, api with projectKey set', function (t) {
 
     function secondSyncfileWritten (err) {
       t.error(err, 'second syncfile written ok')
+      delete lastProgress.timestamp
       t.deepEquals(lastProgress, {
         db: { sofar: 1, total: 1 },
         media: { sofar: 1, total: 1 }
@@ -532,6 +536,7 @@ tape('sync: desktop <-> desktop photos', function (t) {
 
       syncer.on('end', function () {
         t.ok(true, 'replication complete')
+        delete lastProgress.timestamp
         t.deepEquals(lastProgress, {
           db: { sofar: 5, total: 5 },
           media: { sofar: 18, total: 18 }
@@ -647,6 +652,7 @@ tape('sync: deletes are not synced back', function (t) {
 
       syncer.on('end', function () {
         t.ok(true, 'replication complete')
+        delete lastProgress.timestamp
         t.deepEquals(lastProgress, {
           db: { sofar: 5, total: 5 },
           media: { sofar: 18, total: 18 }
@@ -1031,13 +1037,12 @@ tape('sync: peer.connected property on graceful exit', function (t) {
   })
 })
 
-tape.only('sync: missing data still ends', function (t) {
-  t.plan(18)
+tape('sync: missing data still ends', function (t) {
+  t.plan(16)
   var opts = {api1:{deviceType:'desktop'}, api2:{deviceType:'desktop'}}
   createApis(opts, function (api1, api2, close) {
     var pending = 4
-    var total = 200
-
+    var restarted = false
     var _api1 = null
 
     api1.sync.once('peer', written.bind(null, null))
@@ -1048,11 +1053,11 @@ tape.only('sync: missing data still ends', function (t) {
     api2.sync.listen(() => {
       api2.sync.join()
     })
-    helpers.writeBigData(api1, total, written)
-    writeBlob(api2, 'goodbye_world.png', written)
+    helpers.writeBigDataNoPhotos(api1, 450, written)
+    helpers.writeBigDataNoPhotos(api2, 450, written)
 
     function written (err) {
-      t.error(err)
+      t.error(err, 'written no error')
       if (--pending === 0) {
         t.ok(api1.sync.peers().length > 0, 'api 1 has peers')
         t.ok(api2.sync.peers().length > 0, 'api 2 has peers')
@@ -1068,19 +1073,25 @@ tape.only('sync: missing data still ends', function (t) {
         api1.osm.close(() => {
           t.error(err, 'closed first api')
           _api1 = helpers.createApi(api1._dir)
-          _api1.sync.listen(() => {
-            api2.sync.once('peer', (peer) => {
-              sync(peer, false)
+          helpers.writeBigDataNoPhotos(_api1, 200, () => {
+            _api1.sync.listen(() => {
+              api2.sync.once('peer', (peer) => {
+                sync(peer, false)
+              })
+              _api1.sync.join()
             })
-            _api1.sync.join()
           })
         })
       })
     }
 
-    function done (cb) {
+    function done () {
       _api1.close(() => {
-        close(cb)
+        _api1.osm.close(() => {
+          api2.close(() => {
+            t.end()
+          })
+        })
       })
     }
 
@@ -1089,27 +1100,29 @@ tape.only('sync: missing data still ends', function (t) {
       api2.sync.once('down', (peer) => {
         t.pass('emit down event on close')
         t.notOk(peer.connected, 'not connected anymore')
+        if (!first) done()
       })
       var syncer = api2.sync.replicate(peer)
       syncer.on('error', function (err) {
-        t.ok(err)
+        if (first) t.ok(err)
+        else t.same(err.message, 'missing data', 'error message for missing data')
       })
 
       var totalProgressEvents = 0
       var lastProgress
       syncer.on('progress', function (progress) {
-        if (first && !lastProgress) {
+        if (first && progress.db.sofar > 0 && progress.db.sofar < 5 && !restarted) {
           t.ok(peer.started, 'started is true')
           restart()
+          restarted = true
         }
+
         lastProgress = progress
         totalProgressEvents += 1
-        console.log(totalProgressEvents)
       })
 
       syncer.on('end', function () {
         t.ok(true, 'replication complete')
-        if (!first) done()
       })
     }
   })
@@ -1195,6 +1208,7 @@ tape('sync: 200 photos & close/reopen real-world scenario', function (t) {
             'preview/goodbye_world.png',
             'thumbnail/goodbye_world.png'
           ])
+        delete lastProgress.timestamp
         t.deepEquals(lastProgress, {
           db: { sofar: total, total: total },
           media: { sofar: expectedMedia.length, total: expectedMedia.length }


### PR DESCRIPTION
I added a temporary hack, based on conversations with @noffle, who said that making hypercore sparse might be more to to chew than we can at the moment... a proper fix can come in v9

1. I backported the `remote-feeds` event from multifeed v5 into multifeed v4.
2. Updated sync progress to include upload as well as download events.
3. Added a heartbeat to the sync -- every 20s, it checks to see if it has had any progress (media or db#upload or db#download) events in the past 20s. If not, it aborts the sync.

