### PR TITLE
Fix/missing data bug

### DIFF
--- a/lib/db-sync-progress.js
+++ b/lib/db-sync-progress.js
@@ -40,6 +40,11 @@ module.exports = function (db, opts) {
       updateFeed(feed)
     }
     listeners.push({ feed, listener })
+    // XXX: This is important because at least one progress event should be
+    // emitted to ensure the state moves from 'started' to 'progress'
+    // indicating up the stack that progress tracking has begun
+    // for more accurate state
+    updateFeed()
   }
 
   function updateFeed (feed) {

--- a/sync.js
+++ b/sync.js
@@ -255,6 +255,7 @@ class Sync extends events.EventEmitter {
     }
 
     peer.handshake.accept()
+    delete peer.handshake
     return peer.sync
   }
 

--- a/sync.js
+++ b/sync.js
@@ -102,7 +102,12 @@ class SyncState {
   }
 
   stale (peer) {
-    var NOT_STALE = [ReplicationState.STARTED, ReplicationState.ERROR, ReplicationState.COMPLETE, ReplicationState.WIFI_READY]
+    var NOT_STALE = [
+      ReplicationState.STARTED,
+      ReplicationState.ERROR,
+      ReplicationState.COMPLETE,
+      ReplicationState.WIFI_READY
+    ]
     if (NOT_STALE.indexOf(peer.state.topic) > -1) return false
 
     // XXX: This is important because this peer can get in a state where it's in

--- a/test/db-sync-progress.js
+++ b/test/db-sync-progress.js
@@ -63,8 +63,8 @@ test('sync progress: 6 entries', function (t) {
       var a = sync(db1, { live: false })
       var b = sync(db2, { live: false })
 
-      var eventsLeftA = 12
-      var eventsLeftB = 12
+      var eventsLeftA = 15
+      var eventsLeftB = 15
       a.on('progress', function (sofar, total) {
         eventsLeftA--
       })
@@ -163,9 +163,9 @@ test('sync progress: 3 devices', function (t) {
 
         pump(a, b, a, function (err) {
           t.error(err)
-          t.same(aEvents, 12, 'a # of progress events')
-          t.same(bEvents, 12, 'b # of progress events')
-          t.same(cEvents, 1, 'c # of progress events')
+          t.same(aEvents, 15, 'a # of progress events')
+          t.same(bEvents, 15, 'b # of progress events')
+          t.same(cEvents, 2, 'c # of progress events')
           t.same(aLastProgress.sofar, aLastProgress.total, 'a progress ok')
           t.same(bLastProgress.sofar, bLastProgress.total, 'b progress ok')
           t.same(cLastProgress.sofar, cLastProgress.total, 'c progress ok')

--- a/test/sync.js
+++ b/test/sync.js
@@ -1045,7 +1045,7 @@ tape('sync: missing data still ends', function (t) {
     var restarted = false
     var _api1 = null
 
-    let num = 0
+    let numSyncs = 0
 
     api1.sync.once('peer', written.bind(null, null))
     api2.sync.once('peer', written.bind(null, null))
@@ -1099,12 +1099,12 @@ tape('sync: missing data still ends', function (t) {
 
     function sync (peer, cb) {
       if (!cb) cb = () => {}
-      t.ok(peer, 'syncronizing ' + num)
-      num++
+      t.ok(peer, 'syncronizing ' + numSyncs)
+      numSyncs++
       api2.sync.once('down', (downPeer) => {
         t.pass('emit down event on close')
         t.notOk(downPeer.connected, 'not connected anymore')
-        if (num === 2) {
+        if (numSyncs === 2) {
           // SYNC AGAIN!
           api2.sync.once('peer', (_peer) => {
             if (peer.id === _peer.id) sync(_peer, done)
@@ -1114,12 +1114,12 @@ tape('sync: missing data still ends', function (t) {
       })
       var syncer = api2.sync.replicate(peer)
       syncer.on('error', function (err) {
-        if (num === 1) t.ok(err, 'error on first ok')
-        else if (num === 2) t.same(err.message, 'timed out due to missing data', 'error message for missing data')
+        if (numSyncs === 1) t.ok(err, 'error on first ok')
+        else if (numSyncs === 2) t.same(err.message, 'timed out due to missing data', 'error message for missing data')
       })
 
       syncer.on('progress', function (progress) {
-        if (num === 1 && progress.db.sofar > 450 && progress.db.sofar < 455 && !restarted) {
+        if (numSyncs === 1 && progress.db.sofar > 450 && progress.db.sofar < 455 && !restarted) {
           t.ok(peer.started, 'started is true')
           restart()
           restarted = true

--- a/test/sync.js
+++ b/test/sync.js
@@ -1038,12 +1038,14 @@ tape('sync: peer.connected property on graceful exit', function (t) {
 })
 
 tape('sync: missing data still ends', function (t) {
-  t.plan(18)
+  t.plan(19)
   var opts = {api1:{deviceType:'desktop'}, api2:{deviceType:'desktop'}}
   createApis(opts, function (api1, api2, close) {
     var pending = 4
     var restarted = false
     var _api1 = null
+
+    let num = 0
 
     api1.sync.once('peer', written.bind(null, null))
     api2.sync.once('peer', written.bind(null, null))
@@ -1062,7 +1064,7 @@ tape('sync: missing data still ends', function (t) {
         t.ok(api1.sync.peers().length > 0, 'api 1 has peers')
         t.ok(api2.sync.peers().length > 0, 'api 2 has peers')
         if (api2.sync.peers().length >= 1) {
-          sync(api2.sync.peers()[0], true)
+          sync(api2.sync.peers()[0])
         }
       }
     }
@@ -1076,7 +1078,7 @@ tape('sync: missing data still ends', function (t) {
           helpers.writeBigDataNoPhotos(_api1, 200, () => {
             _api1.sync.listen(() => {
               api2.sync.once('peer', (peer) => {
-                sync(peer, false)
+                sync(peer)
               })
               _api1.sync.join()
             })
@@ -1095,27 +1097,29 @@ tape('sync: missing data still ends', function (t) {
       })
     }
 
-    function sync (peer, first, cb) {
+    function sync (peer, cb) {
       if (!cb) cb = () => {}
-      t.ok(peer, 'syncronizing ' + first)
-      api2.sync.on('down', (peer) => {
+      t.ok(peer, 'syncronizing ' + num)
+      num++
+      api2.sync.once('down', (downPeer) => {
         t.pass('emit down event on close')
-        t.notOk(peer.connected, 'not connected anymore')
-        if (!first) {
+        t.notOk(downPeer.connected, 'not connected anymore')
+        if (num === 2) {
           // SYNC AGAIN!
-          api2.sync.once('peer', (peer) => {
-            sync(peer, false, done)
+          api2.sync.once('peer', (_peer) => {
+            if (peer.id === _peer.id) sync(_peer, done)
           })
         }
+        cb()
       })
       var syncer = api2.sync.replicate(peer)
       syncer.on('error', function (err) {
-        if (first) t.ok(err, 'error on first ok')
-        else t.same(err.message, 'timed out due to missing data', 'error message for missing data')
+        if (num === 1) t.ok(err, 'error on first ok')
+        else if (num === 2) t.same(err.message, 'timed out due to missing data', 'error message for missing data')
       })
 
       syncer.on('progress', function (progress) {
-        if (first && progress.db.sofar > 450 && progress.db.sofar < 455 && !restarted) {
+        if (num === 1 && progress.db.sofar > 450 && progress.db.sofar < 455 && !restarted) {
           t.ok(peer.started, 'started is true')
           restart()
           restarted = true
@@ -1124,7 +1128,6 @@ tape('sync: missing data still ends', function (t) {
 
       syncer.on('end', function () {
         t.ok(true, 'replication complete')
-        cb()
       })
     }
   })


### PR DESCRIPTION
Waded through this bug today -- found it while testing the missing data behavior.

When a sync with a peer with missing data occurred, and then you synced again without exiting mapeo on either side, it would report 'tried to sync before handshake occurred' OR if it got past that, it would crash node because peer.state.message.db did not exist as it was in the `STARTED` state.

