### PR TITLE
Test and fix this.swarm being called when undefined #116

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -410,7 +410,12 @@ class Sync extends events.EventEmitter {
   // Stop listening for project key
   leave (projectKey) {
     var key = discoveryKey(projectKey)
-    this.swarm.leave(key)
+    debug('sync leave')
+    if (this.swarm) this.swarm.leave(key)
+    else {
+      debug('sync leaving silently')
+      return
+    }
   }
 
   // Start listening for project key

--- a/test/sync.js
+++ b/test/sync.js
@@ -188,7 +188,7 @@ tape('sync: trying to sync to unknown peer', function (t) {
 
 tape('sync: leave even if swarm is undefined', function (t) {
   var api1 = helpers.createApi(null)
-  t.notOk(api1.sync.leave())
+  api1.sync.leave()
   api1.close()
   t.end()
 })

--- a/test/sync.js
+++ b/test/sync.js
@@ -186,6 +186,13 @@ tape('sync: trying to sync to unknown peer', function (t) {
   })
 })
 
+tape('sync: leave even if swarm is undefined', function (t) {
+  var api1 = helpers.createApi(null)
+  t.notOk(api1.sync.leave())
+  api1.close()
+  t.end()
+})
+
 tape('sync: two servers find each other with default sync key', function (t) {
   t.plan(3)
 


### PR DESCRIPTION
- test: assert leaving sync works even if swarm is undefined
- fix: silently return from sync leave if this.swarm is undefined (#89)
