### PR TITLE
fix: Fix logic for determining if an external file can be synced with 

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ Both `replicate` and `replicateNetwork` return an EventEmitter `ev`. It can emit
 
 Valid `opts` include:
 
+- `opts.fromNewlyCreatedSyncFile` (boolean): a flag used by `replicateFromFile` to indicate that the target file was created just before the attempt to sync with it, as opposed to some pre-existing file created in some other context.
+
 - `opts.projectKey` (string): a unique identifier that prohibits sync with a
   syncfile that declares a different project ID. If either side doesn't have a
   project ID set, sync will be permitted.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Both `replicate` and `replicateNetwork` return an EventEmitter `ev`. It can emit
 
 Valid `opts` include:
 
-- `opts.fromNewlyCreatedSyncFile` (boolean): a flag used by `replicateFromFile` to indicate that the target file was created just before the attempt to sync with it, as opposed to some pre-existing file created in some other context.
+- `opts.createFile` (boolean): a flag used by `replicateFromFile` to indicate that the target file needs to be created before attempting to sync with it, as opposed to using some pre-existing file created in a different context.
 
 - `opts.projectKey` (string): a unique identifier that prohibits sync with a
   syncfile that declares a different project ID. If either side doesn't have a

--- a/sync.js
+++ b/sync.js
@@ -448,6 +448,7 @@ class Sync extends events.EventEmitter {
   /**
    * Replicate from a given file. Use `replicate` instead.
    * @param  {String}   peer    A peer.
+   * @param {{fromNewlyCreatedSyncFile: ?boolean, projectKey: ?string, writeFormat: ?string}} [opts]
    * @return {EventEmitter}     Listen to 'error', 'end' and 'progress' events
    */
   replicateFromFile (peer, opts) {
@@ -479,9 +480,29 @@ class Sync extends events.EventEmitter {
           if (data && data['p2p-db'] && data['p2p-db'] !== 'kappa-osm') {
             return onerror(new Error('trying to sync this kappa-osm database with a ' + data['p2p-db'] + ' database!'))
           }
-          if (data && data.discoveryKey && opts.projectKey && data.discoveryKey !== discoKey) {
-            return onerror(new Error(`trying to sync two different projects (us=${discoKey}) (syncfile=${data.discoveryKey})`))
+
+          const intoDefaultProject = !opts.projectKey
+          const fileDiscoveryKey = data && data.discoveryKey
+          const canSyncWhenNoFileDiscoveryKey =
+            !fileDiscoveryKey && (intoDefaultProject || opts.fromNewlyCreatedSyncFile)
+
+          if (canSyncWhenNoFileDiscoveryKey) {
+            start()
+            return
           }
+
+          const areDifferentProjects =
+            (fileDiscoveryKey && intoDefaultProject) ||
+            (!intoDefaultProject && fileDiscoveryKey !== discoKey)
+
+          if (areDifferentProjects) {
+            return onerror(
+              new Error(
+                `trying to sync two different projects (us=${discoKey}) (syncfile=${data.discoveryKey})`
+              )
+            )
+          }
+
           start()
         })
       })


### PR DESCRIPTION
Addresses https://github.com/digidem/mapeo-desktop/issues/510

Notes:
- Adds an option `createFile` to `replicate` that's used by `replicateFromFile` to denote that the target file needs to be created and then synced with, as opposed to using some pre-existing sync file created in a different context